### PR TITLE
feat: add observability (metrics) for sqlquery receiver

### DIFF
--- a/receiver/sqlqueryreceiver/internal/observability/observability.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability.go
@@ -24,8 +24,7 @@ import (
 
 func init() {
 	err := view.Register(
-		viewCollectedLogs,
-		viewCollectedAccumulated,
+		viewCollectedTotal,
 	)
 	if err != nil {
 		fmt.Printf("Failed to register sqlquery receiver's views: %v\n", err)
@@ -33,23 +32,14 @@ func init() {
 }
 
 var (
-	mLogsCollected                = stats.Int64("receiver/logs/collected", "Number of logs collected in the collection interval", "")
-	mLogsCollectedLogsAccumulated = stats.Int64("receiver/logs/collected_accumulated", "Number of logs collected", "")
-	receiverKey, _                = tag.NewKey("receiver") // nolint:errcheck
+	mLogsCollectedLogs = stats.Int64("receiver/collected/log/records", "Number of collected logs", "")
+	receiverKey, _     = tag.NewKey("receiver") // nolint:errcheck
 )
 
-var viewCollectedLogs = &view.View{
-	Name:        mLogsCollected.Name(),
-	Description: mLogsCollected.Description(),
-	Measure:     mLogsCollected,
-	TagKeys:     []tag.Key{receiverKey},
-	Aggregation: view.LastValue(),
-}
-
-var viewCollectedAccumulated = &view.View{
-	Name:        mLogsCollectedLogsAccumulated.Name(),
-	Description: mLogsCollectedLogsAccumulated.Description(),
-	Measure:     mLogsCollectedLogsAccumulated,
+var viewCollectedTotal = &view.View{
+	Name:        mLogsCollectedLogs.Name(),
+	Description: mLogsCollectedLogs.Description(),
+	Measure:     mLogsCollectedLogs,
 	TagKeys:     []tag.Key{receiverKey},
 	Aggregation: view.Sum(),
 }
@@ -60,16 +50,6 @@ func RecordCollectedLogs(collectedLogs int64, receiver string) error {
 		[]tag.Mutator{
 			tag.Insert(receiverKey, receiver),
 		},
-		mLogsCollected.M(collectedLogs),
-	)
-}
-
-func RecordCollectedLogsAccumulated(collectedLogs int64, receiver string) error {
-	return stats.RecordWithTags(
-		context.Background(),
-		[]tag.Mutator{
-			tag.Insert(receiverKey, receiver),
-		},
-		mLogsCollectedLogsAccumulated.M(collectedLogs),
+		mLogsCollectedLogs.M(collectedLogs),
 	)
 }

--- a/receiver/sqlqueryreceiver/internal/observability/observability.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package observability
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	err := view.Register(
+		viewCollectedLogs,
+		viewCollectedAccumulated,
+	)
+	if err != nil {
+		fmt.Printf("Failed to register sqlquery receiver's views: %v\n", err)
+	}
+}
+
+var (
+	mLogsCollected                = stats.Int64("receiver/logs/collected", "Number of logs collected in the collection interval", "")
+	mLogsCollectedLogsAccumulated = stats.Int64("receiver/logs/collected_accumulated", "Number of logs collected", "")
+	receiverKey, _                = tag.NewKey("receiver") // nolint:errcheck
+)
+
+var viewCollectedLogs = &view.View{
+	Name:        mLogsCollected.Name(),
+	Description: mLogsCollected.Description(),
+	Measure:     mLogsCollected,
+	TagKeys:     []tag.Key{receiverKey},
+	Aggregation: view.LastValue(),
+}
+
+var viewCollectedAccumulated = &view.View{
+	Name:        mLogsCollectedLogsAccumulated.Name(),
+	Description: mLogsCollectedLogsAccumulated.Description(),
+	Measure:     mLogsCollectedLogsAccumulated,
+	TagKeys:     []tag.Key{receiverKey},
+	Aggregation: view.Sum(),
+}
+
+func RecordCollectedLogs(collectedLogs int64, receiver string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(receiverKey, receiver),
+		},
+		mLogsCollected.M(collectedLogs),
+	)
+}
+
+func RecordCollectedLogsAccumulated(collectedLogs int64, receiver string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(receiverKey, receiver),
+		},
+		mLogsCollectedLogsAccumulated.M(collectedLogs),
+	)
+}

--- a/receiver/sqlqueryreceiver/internal/observability/observability.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	err := view.Register(
-		viewCollectedTotal,
+		viewAcceptedLogs,
 	)
 	if err != nil {
 		fmt.Printf("Failed to register sqlquery receiver's views: %v\n", err)
@@ -32,24 +32,26 @@ func init() {
 }
 
 var (
-	mLogsCollectedLogs = stats.Int64("receiver/collected/log/records", "Number of collected logs", "")
-	receiverKey, _     = tag.NewKey("receiver") // nolint:errcheck
+	mAcceptedLogs  = stats.Int64("receiver/accepted/log/records", "Number of log record pushed into the pipeline.", "")
+	receiverKey, _ = tag.NewKey("receiver") // nolint:errcheck
+	queryKey, _    = tag.NewKey("query")    // nolint:errcheck
 )
 
-var viewCollectedTotal = &view.View{
-	Name:        mLogsCollectedLogs.Name(),
-	Description: mLogsCollectedLogs.Description(),
-	Measure:     mLogsCollectedLogs,
-	TagKeys:     []tag.Key{receiverKey},
+var viewAcceptedLogs = &view.View{
+	Name:        mAcceptedLogs.Name(),
+	Description: mAcceptedLogs.Description(),
+	Measure:     mAcceptedLogs,
+	TagKeys:     []tag.Key{receiverKey, queryKey},
 	Aggregation: view.Sum(),
 }
 
-func RecordCollectedLogs(collectedLogs int64, receiver string) error {
+func RecordAcceptedLogs(acceptedLogs int64, receiver string, query string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(receiverKey, receiver),
+			tag.Insert(queryKey, query),
 		},
-		mLogsCollectedLogs.M(collectedLogs),
+		mAcceptedLogs.M(acceptedLogs),
 	)
 }

--- a/receiver/sqlqueryreceiver/internal/observability/observability_test.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability_test.go
@@ -99,13 +99,8 @@ func TestMetrics(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			name:       "receiver/logs/collected",
+			name:       "receiver/collected/log/records",
 			recordFunc: "RecordCollectedLogs",
-			value:      3,
-		},
-		{
-			name:       "receiver/logs/collected_accumulated",
-			recordFunc: "RecordCollectedLogsAccumulated",
 			value:      10,
 		},
 	}
@@ -121,8 +116,6 @@ func TestMetrics(t *testing.T) {
 		switch tt.recordFunc {
 		case "RecordCollectedLogs":
 			require.NoError(t, RecordCollectedLogs(tt.value, receiver))
-		case "RecordCollectedLogsAccumulated":
-			require.NoError(t, RecordCollectedLogsAccumulated(tt.value, receiver))
 		}
 	}
 
@@ -150,11 +143,8 @@ func TestMetrics(t *testing.T) {
 			require.Len(t, d.TimeSeries, 1)
 			require.Len(t, d.TimeSeries[0].Points, 1)
 			assert.Equal(t, d.TimeSeries[0].Points[0].Value, tt.value)
-
 			require.Len(t, d.TimeSeries[0].LabelValues, 1)
-
 			require.True(t, d.TimeSeries[0].LabelValues[0].Present)
-
 			assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, receiver)
 		})
 	}

--- a/receiver/sqlqueryreceiver/internal/observability/observability_test.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package observability
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+)
+
+type exporter struct {
+	pipe chan *metricdata.Metric
+}
+
+func newExporter() *exporter {
+	return &exporter{
+		make(chan *metricdata.Metric),
+	}
+}
+
+// Run goroutine which is going to receive `after` metrics.
+// Goroutine is writing to returned chan
+func (e *exporter) ReturnAfter(after int) chan []*metricdata.Metric {
+	ch := make(chan []*metricdata.Metric)
+	go func() {
+		received := []*metricdata.Metric{}
+		for m := range e.pipe {
+			received = append(received, m)
+			if len(received) >= after {
+				break
+			}
+		}
+		ch <- received
+	}()
+	return ch
+}
+
+// Write received metrics to data channel
+func (e *exporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	for _, m := range data {
+		e.pipe <- m
+	}
+	return nil
+}
+
+// Creates metrics reader and forward metrics from it to chData
+// Sens empty structs to fail chan afterwards
+func metricReader(chData chan []*metricdata.Metric, fail chan struct{}, count int) {
+	reader := metricexport.NewReader()
+	e := newExporter()
+	ch := e.ReturnAfter(count)
+
+	// Add a manual retry mechanism in case there's a hiccup reading the
+	// metrics from producers in ReadAndExport(): we can wait for the metrics
+	// to come instead of failing because they didn't come right away.
+	for i := 0; i < 10; i++ {
+		go reader.ReadAndExport(e)
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+
+		case data := <-ch:
+			chData <- data
+			return
+		}
+	}
+
+	fail <- struct{}{}
+}
+
+// NOTE:
+// This test can only be run with count 1 because of static
+// metricproducer.GlobalManager() used in metricexport.NewReader().
+func TestMetrics(t *testing.T) {
+	const (
+		receiver = "sqlquery/my-name"
+	)
+	type testCase struct {
+		name       string
+		recordFunc string
+		value      int64
+	}
+	tests := []testCase{
+		{
+			name:       "receiver/logs/collected",
+			recordFunc: "RecordCollectedLogs",
+			value:      3,
+		},
+		{
+			name:       "receiver/logs/collected_accumulated",
+			recordFunc: "RecordCollectedLogsAccumulated",
+			value:      10,
+		},
+	}
+
+	var (
+		fail   = make(chan struct{})
+		chData = make(chan []*metricdata.Metric)
+	)
+
+	go metricReader(chData, fail, len(tests))
+
+	for _, tt := range tests {
+		switch tt.recordFunc {
+		case "RecordCollectedLogs":
+			require.NoError(t, RecordCollectedLogs(tt.value, receiver))
+		case "RecordCollectedLogsAccumulated":
+			require.NoError(t, RecordCollectedLogsAccumulated(tt.value, receiver))
+		}
+	}
+
+	var data []*metricdata.Metric
+	select {
+	case <-fail:
+		t.Fatalf("timedout waiting for metrics to arrive")
+	case data = <-chData:
+	}
+
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].name < tests[j].name
+	})
+
+	sort.Slice(data, func(i, j int) bool {
+		return data[i].Descriptor.Name < data[j].Descriptor.Name
+	})
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Len(t, data, len(tests))
+
+			d := data[i]
+			assert.Equal(t, d.Descriptor.Name, tt.name)
+			require.Len(t, d.TimeSeries, 1)
+			require.Len(t, d.TimeSeries[0].Points, 1)
+			assert.Equal(t, d.TimeSeries[0].Points[0].Value, tt.value)
+
+			require.Len(t, d.TimeSeries[0].LabelValues, 1)
+
+			require.True(t, d.TimeSeries[0].LabelValues[0].Present)
+
+			assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, receiver)
+		})
+	}
+}

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -42,6 +42,8 @@ type logsReceiver struct {
 	isStarted                bool
 	collectionIntervalTicker *time.Ticker
 	shutdownRequested        chan struct{}
+
+	id component.ID
 }
 
 func newLogsReceiver(
@@ -60,6 +62,7 @@ func newLogsReceiver(
 		createClient:      createClient,
 		nextConsumer:      nextConsumer,
 		shutdownRequested: make(chan struct{}),
+		id:                settings.ID,
 	}
 
 	receiver.createQueryReceivers()
@@ -72,7 +75,7 @@ func (receiver *logsReceiver) createQueryReceivers() {
 		if len(query.Logs) == 0 {
 			continue
 		}
-		id := component.NewIDWithName("sqlqueryreceiver", fmt.Sprintf("query-%d: %s", i, query.SQL))
+		id := fmt.Sprintf("query-%d: %s", i, query.SQL)
 		queryReceiver := newLogsQueryReceiver(
 			id,
 			query,
@@ -124,11 +127,11 @@ func (receiver *logsReceiver) collect() {
 		go func(queryReceiver *logsQueryReceiver) {
 			logs, err := queryReceiver.collect(context.Background())
 			if err != nil {
-				receiver.settings.Logger.Error("Error collecting logs", zap.Error(err), zap.Stringer("scraper", queryReceiver.ID()))
+				receiver.settings.Logger.Error("Error collecting logs", zap.Error(err), zap.String("query", queryReceiver.ID()))
 			}
 
-			if err := observability.RecordCollectedLogs(int64(logs.LogRecordCount()), queryReceiver.id.String()); err != nil {
-				receiver.settings.Logger.Debug("error for recording metric for number of collected logs", zap.Error(err))
+			if err := observability.RecordAcceptedLogs(int64(logs.LogRecordCount()), receiver.id.String(), queryReceiver.id); err != nil {
+				receiver.settings.Logger.Debug("error recording metric for number of collected logs", zap.Error(err))
 			}
 
 			logsChannel <- logs
@@ -169,7 +172,7 @@ func (receiver *logsReceiver) stopCollecting() {
 }
 
 type logsQueryReceiver struct {
-	id           component.ID
+	id           string
 	query        Query
 	createDb     dbProviderFunc
 	createClient clientProviderFunc
@@ -181,7 +184,7 @@ type logsQueryReceiver struct {
 }
 
 func newLogsQueryReceiver(
-	id component.ID,
+	id string,
 	query Query,
 	dbProviderFunc dbProviderFunc,
 	clientProviderFunc clientProviderFunc,
@@ -198,7 +201,7 @@ func newLogsQueryReceiver(
 	return queryReceiver
 }
 
-func (queryReceiver *logsQueryReceiver) ID() component.ID {
+func (queryReceiver *logsQueryReceiver) ID() string {
 	return queryReceiver.id
 }
 


### PR DESCRIPTION
This pull requests `otelcol_receiver_collected_log_records` metric for sqlquery receiver

```
# HELP otelcol_receiver_collected_log_records Number of collected logs
# TYPE otelcol_receiver_collected_log_records counter
otelcol_receiver_collected_log_records{receiver="sqlqueryreceiver/query-0: select * from simple_logs",service_instance_id="3c7aebcc-8fc8-4cf3-9e80-aecea7a4af8f",service_name="otelcol-sumo",service_version="v0.70.0-sumo-0-198-g210a3dfb53"} 5
```
It uses the same mechanism for adding and testing metrics as [sumologic exporter](https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter/internal/observability) uses.

In another pull request I'm going to add metric for count errors.