### PR TITLE
feat(sqlqueryreceiver) add error count metrics for receiver

### DIFF
--- a/receiver/sqlqueryreceiver/internal/observability/observability.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	mAcceptedLogs = stats.Int64("receiver/accepted/log/records", "Number of log record pushed into the pipeline.", "")
-	mErrorCount   = stats.Int64("receiver/error/count", "Number of errors", "")
+	mErrorCount   = stats.Int64("receiver/errors", "Number of errors", "")
 
 	receiverKey, _  = tag.NewKey("receiver")   // nolint:errcheck
 	queryKey, _     = tag.NewKey("query")      // nolint:errcheck
@@ -73,7 +73,7 @@ func RecordAcceptedLogs(acceptedLogs int64, receiver string, query string) error
 	)
 }
 
-func RecordErrorCount(errorType string, receiver string, query string) error {
+func RecordErrors(errorType string, receiver string, query string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
@@ -85,7 +85,7 @@ func RecordErrorCount(errorType string, receiver string, query string) error {
 	)
 }
 
-func RecordNoErrorCount(errorType string, receiver string, query string) error {
+func RecordNoErrors(errorType string, receiver string, query string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{

--- a/receiver/sqlqueryreceiver/internal/observability/observability.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability.go
@@ -25,16 +25,25 @@ import (
 func init() {
 	err := view.Register(
 		viewAcceptedLogs,
+		viewErrorCount,
 	)
 	if err != nil {
 		fmt.Printf("Failed to register sqlquery receiver's views: %v\n", err)
 	}
 }
 
+const (
+	StartError   = "start_error"
+	CollectError = "collect_error"
+)
+
 var (
-	mAcceptedLogs  = stats.Int64("receiver/accepted/log/records", "Number of log record pushed into the pipeline.", "")
-	receiverKey, _ = tag.NewKey("receiver") // nolint:errcheck
-	queryKey, _    = tag.NewKey("query")    // nolint:errcheck
+	mAcceptedLogs = stats.Int64("receiver/accepted/log/records", "Number of log record pushed into the pipeline.", "")
+	mErrorCount   = stats.Int64("receiver/error/count", "Number of errors", "")
+
+	receiverKey, _  = tag.NewKey("receiver")   // nolint:errcheck
+	queryKey, _     = tag.NewKey("query")      // nolint:errcheck
+	errorTypeKey, _ = tag.NewKey("error_type") // nolint:errcheck
 )
 
 var viewAcceptedLogs = &view.View{
@@ -42,6 +51,14 @@ var viewAcceptedLogs = &view.View{
 	Description: mAcceptedLogs.Description(),
 	Measure:     mAcceptedLogs,
 	TagKeys:     []tag.Key{receiverKey, queryKey},
+	Aggregation: view.Sum(),
+}
+
+var viewErrorCount = &view.View{
+	Name:        mErrorCount.Name(),
+	Description: mErrorCount.Description(),
+	Measure:     mErrorCount,
+	TagKeys:     []tag.Key{receiverKey, queryKey, errorTypeKey},
 	Aggregation: view.Sum(),
 }
 
@@ -53,5 +70,29 @@ func RecordAcceptedLogs(acceptedLogs int64, receiver string, query string) error
 			tag.Insert(queryKey, query),
 		},
 		mAcceptedLogs.M(acceptedLogs),
+	)
+}
+
+func RecordErrorCount(errorType string, receiver string, query string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(receiverKey, receiver),
+			tag.Insert(queryKey, query),
+			tag.Insert(errorTypeKey, errorType),
+		},
+		mErrorCount.M(int64(1)),
+	)
+}
+
+func RecordNoErrorCount(errorType string, receiver string, query string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(receiverKey, receiver),
+			tag.Insert(queryKey, query),
+			tag.Insert(errorTypeKey, errorType),
+		},
+		mErrorCount.M(int64(0)),
 	)
 }

--- a/receiver/sqlqueryreceiver/internal/observability/observability_test.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability_test.go
@@ -86,20 +86,34 @@ func metricReader(chData chan []*metricdata.Metric, fail chan struct{}, count in
 }
 
 func TestMetrics(t *testing.T) {
-	const (
-		receiver      = "sqlquery/my-name"
-		queryReceiver = "query-0: select * from simple_logs"
-	)
 	type testCase struct {
-		name       string
-		recordFunc string
-		value      int64
+		name        string
+		recordFunc  string
+		value       int64
+		labels      map[string]string
+		labelsOrder []string // order of labels in timeseries, label values have the same order as keys in the metric descriptor
 	}
 	tests := []testCase{
 		{
 			name:       "receiver/accepted/log/records",
 			recordFunc: "RecordAcceptedLogs",
 			value:      10,
+			labels: map[string]string{
+				"receiver": "sqlquery/my-name",
+				"query":    "query-0: select * from simple_logs",
+			},
+			labelsOrder: []string{"query", "receiver"},
+		},
+		{
+			name:       "receiver/error/count",
+			recordFunc: "RecordErrorCount",
+			value:      1,
+			labels: map[string]string{
+				"receiver":   "sqlquery/my-logs",
+				"query":      "query-1: select * from simple_logs",
+				"error_type": StartError,
+			},
+			labelsOrder: []string{"error_type", "query", "receiver"},
 		},
 	}
 
@@ -113,7 +127,11 @@ func TestMetrics(t *testing.T) {
 	for _, tt := range tests {
 		switch tt.recordFunc {
 		case "RecordAcceptedLogs":
-			require.NoError(t, RecordAcceptedLogs(tt.value, receiver, queryReceiver))
+			require.NoError(t, RecordAcceptedLogs(tt.value, tt.labels["receiver"], tt.labels["query"]))
+		case "RecordErrorCount":
+			require.NoError(t, RecordErrorCount(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
+		case "RecordNoErrorCount":
+			require.NoError(t, RecordNoErrorCount(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
 		}
 	}
 
@@ -141,11 +159,14 @@ func TestMetrics(t *testing.T) {
 			require.Len(t, d.TimeSeries, 1)
 			require.Len(t, d.TimeSeries[0].Points, 1)
 			assert.Equal(t, d.TimeSeries[0].Points[0].Value, tt.value)
-			require.Len(t, d.TimeSeries[0].LabelValues, 2)
-			require.True(t, d.TimeSeries[0].LabelValues[0].Present)
-			assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, queryReceiver)
-			require.True(t, d.TimeSeries[0].LabelValues[1].Present)
-			assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, receiver)
+			require.Len(t, d.TimeSeries[0].LabelValues, len(tt.labels))
+
+			for i, label := range d.TimeSeries[0].LabelValues {
+				val, ok := tt.labels[tt.labelsOrder[i]]
+				assert.True(t, ok)
+				assert.True(t, label.Present)
+				assert.Equal(t, label.Value, val)
+			}
 		})
 	}
 }

--- a/receiver/sqlqueryreceiver/internal/observability/observability_test.go
+++ b/receiver/sqlqueryreceiver/internal/observability/observability_test.go
@@ -105,8 +105,8 @@ func TestMetrics(t *testing.T) {
 			labelsOrder: []string{"query", "receiver"},
 		},
 		{
-			name:       "receiver/error/count",
-			recordFunc: "RecordErrorCount",
+			name:       "receiver/errors",
+			recordFunc: "RecordErrors",
 			value:      1,
 			labels: map[string]string{
 				"receiver":   "sqlquery/my-logs",
@@ -128,10 +128,10 @@ func TestMetrics(t *testing.T) {
 		switch tt.recordFunc {
 		case "RecordAcceptedLogs":
 			require.NoError(t, RecordAcceptedLogs(tt.value, tt.labels["receiver"], tt.labels["query"]))
-		case "RecordErrorCount":
-			require.NoError(t, RecordErrorCount(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
-		case "RecordNoErrorCount":
-			require.NoError(t, RecordNoErrorCount(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
+		case "RecordErrors":
+			require.NoError(t, RecordErrors(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
+		case "RecordNoErrors":
+			require.NoError(t, RecordNoErrors(tt.labels["error_type"], tt.labels["receiver"], tt.labels["query"]))
 		}
 	}
 

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -97,13 +97,13 @@ func (receiver *logsReceiver) Start(ctx context.Context, host component.Host) er
 	for _, queryReceiver := range receiver.queryReceivers {
 		err := queryReceiver.start()
 		if err != nil {
-			if err := observability.RecordErrorCount(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
+			if err := observability.RecordErrors(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
 				receiver.settings.Logger.Debug("error recording metric for errors count", zap.Error(err))
 			}
 			return err
 		}
 
-		if err := observability.RecordNoErrorCount(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
+		if err := observability.RecordNoErrors(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
 			receiver.settings.Logger.Debug("error recording metric for errors count", zap.Error(err))
 		}
 	}
@@ -135,12 +135,12 @@ func (receiver *logsReceiver) collect() {
 			logs, err := queryReceiver.collect(context.Background())
 			if err != nil {
 				receiver.settings.Logger.Error("Error collecting logs", zap.Error(err), zap.String("query", queryReceiver.ID()))
-				if err := observability.RecordErrorCount(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
+				if err := observability.RecordErrors(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
 					receiver.settings.Logger.Debug("error for recording metric for errors count", zap.Error(err))
 				}
 			}
 
-			if err := observability.RecordNoErrorCount(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
+			if err := observability.RecordNoErrors(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
 				receiver.settings.Logger.Debug("error for recording metric for errors count", zap.Error(err))
 			}
 

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -97,9 +97,17 @@ func (receiver *logsReceiver) Start(ctx context.Context, host component.Host) er
 	for _, queryReceiver := range receiver.queryReceivers {
 		err := queryReceiver.start()
 		if err != nil {
+			if err := observability.RecordErrorCount(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
+				receiver.settings.Logger.Debug("error recording metric for errors count", zap.Error(err))
+			}
 			return err
 		}
+
+		if err := observability.RecordNoErrorCount(observability.StartError, receiver.id.String(), queryReceiver.ID()); err != nil {
+			receiver.settings.Logger.Debug("error recording metric for errors count", zap.Error(err))
+		}
 	}
+
 	receiver.startCollecting()
 	receiver.settings.Logger.Debug("started.")
 	return nil
@@ -127,6 +135,13 @@ func (receiver *logsReceiver) collect() {
 			logs, err := queryReceiver.collect(context.Background())
 			if err != nil {
 				receiver.settings.Logger.Error("Error collecting logs", zap.Error(err), zap.String("query", queryReceiver.ID()))
+				if err := observability.RecordErrorCount(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
+					receiver.settings.Logger.Debug("error for recording metric for errors count", zap.Error(err))
+				}
+			}
+
+			if err := observability.RecordNoErrorCount(observability.CollectError, receiver.id.String(), queryReceiver.ID()); err != nil {
+				receiver.settings.Logger.Debug("error for recording metric for errors count", zap.Error(err))
 			}
 
 			if err := observability.RecordAcceptedLogs(int64(logs.LogRecordCount()), receiver.id.String(), queryReceiver.id); err != nil {


### PR DESCRIPTION
Format of metric:
```
# HELP otelcol_receiver_error_count Number of errors
# TYPE otelcol_receiver_error_count counter
otelcol_receiver_error_count{error_type="collect_error",query="query-0: select * from simple_logs",receiver="sqlquery",service_instance_id="9763b7d6-e907-438f-9b70-6e4882756785",service_name="otelcol-sumo",service_version="v0.70.0-sumo-0-198-g210a3dfb53"} 0
otelcol_receiver_error_count{error_type="collect_error",query="query-0: select * from test_logs",receiver="sqlquery/wrong_query",service_instance_id="9763b7d6-e907-438f-9b70-6e4882756785",service_name="otelcol-sumo",service_version="v0.70.0-sumo-0-198-g210a3dfb53"} 2
otelcol_receiver_error_count{error_type="start_error",query="query-0: select * from simple_logs",receiver="sqlquery",service_instance_id="9763b7d6-e907-438f-9b70-6e4882756785",service_name="otelcol-sumo",service_version="v0.70.0-sumo-0-198-g210a3dfb53"} 0
otelcol_receiver_error_count{error_type="start_error",query="query-0: select * from test_logs",receiver="sqlquery/wrong_query",service_instance_id="9763b7d6-e907-438f-9b70-6e4882756785",service_name="otelcol-sumo",service_version="v0.70.0-sumo-0-198-g210a3dfb53"} 0
```
for configuration:
```yaml
receivers:
  sqlquery:
    collection_interval: 10s
    driver: postgres
    datasource: "host=127.0.0.1 port=5432 user=otel password=otel sslmode=disable"
    queries:
      - sql: "select * from simple_logs"
        logs:
        - body_column: BODY

  sqlquery/wrong_query:
    collection_interval: 10s
    driver: postgres
    datasource: "host=127.0.0.1 port=5432 user=otel password=otel sslmode=disable"
    queries:
      - sql: "select * from test_logs"
        logs:
        - body_column: BODY
exporters:
  logging:
    verbosity: detailed
    sampling_initial: 5
    sampling_thereafter: 200

service:
  telemetry:
      logs:
        level: "debug"
  pipelines:
    logs:
      receivers:
        - sqlquery
      exporters:
        - logging
    logs/wrong_query:
      receivers:
        - sqlquery/wrong_query
      exporters:
        - logging
```