### PR TITLE
feat(sqlqueryreceiver) add traces to monitor logs received

### DIFF
--- a/receiver/sqlqueryreceiver/receiver.go
+++ b/receiver/sqlqueryreceiver/receiver.go
@@ -29,7 +29,7 @@ func createLogsReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clie
 		consumer consumer.Logs,
 	) (receiver.Logs, error) {
 		sqlQueryConfig := config.(*Config)
-		return newLogsReceiver(sqlQueryConfig, settings, sqlOpenerFunc, clientProviderFunc, consumer), nil
+		return newLogsReceiver(sqlQueryConfig, settings, sqlOpenerFunc, clientProviderFunc, consumer)
 	}
 }
 


### PR DESCRIPTION
<img width="1095" alt="Screenshot 2023-05-18 at 13 32 04" src="https://github.com/dmolenda-sumo/opentelemetry-collector-contrib/assets/73836361/bcfde67f-c511-446e-92fd-c2e589857359">

Test with following configuration:
```yaml
receivers:
  filelog:
    include: <path>
  hostmetrics:
    scrapers:
      load:
        cpu_average: true
      memory:
  sqlquery:
    collection_interval: 10s
    driver: postgres
    datasource: "host=127.0.0.1 port=5432 user=otel password=otel sslmode=disable"
    queries:
      - sql: "select * from simple_logs"
        logs:
        - body_column: BODY

  statsd:

extensions:
  zpages:

exporters:
  logging:
   loglevel: debug
  file:
    path: <path>
  file/metrics:
    path: <path>

service:
  telemetry:
    logs:
      level: "debug"
  extensions: [zpages]
  pipelines:
    logs:
      receivers:
        - sqlquery
      exporters:
        - file
    logs/file:
      receivers:
        - filelog
      exporters:
        - logging
    metrics:
     receivers: [statsd]
     exporters: [file/metrics]
```